### PR TITLE
Remove facet count text when generating selection

### DIFF
--- a/assets/js/front.js
+++ b/assets/js/front.js
@@ -14,8 +14,9 @@
         var selected_values = [];
         params.el.find('.facetwp-hierarchy_select option:selected').each(function(i) {
             var value = $(this).attr('value');
+            var text = $(this).text().replace(/\([0-9]+\)$/, '');
             if (value.length) {
-                selected_values.push({ value: value, label: $(this).text() });
+                selected_values.push({ value: value, label: text });
             }
         });
         return selected_values;


### PR DESCRIPTION
Here's a regex to remove the (#) number of results counter text when generating a selection element, to match behavior on other facet types.